### PR TITLE
Fix handling of unlinked tokens in Visage module

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ Allows the owner of an Actor to instantly switch a Token's image and name betwee
 
 Software and associated documentation files in this repository are covered by an [MIT License](LICENSE.md).
 
+## Version History
+
+**Version 0.2.1**
+*   Fix issue with reading data from tokens that were not linked to actors
+
+**Version 0.2.0**
+*   Initial build
+
 # Visage Module: Public API Documentation
 
 The **Visage** module exposes a public API that allows other modules, system macros, or advanced users to programmatically interact with its core functionality, such as switching actor forms.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "visage",
   "title": "Visage",
   "description": "Allow token art and actor portraits to be easily switched to alternative images.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "compatibility": {
     "minimum": "13",
     "verified": "13"

--- a/visage-config.js
+++ b/visage-config.js
@@ -165,6 +165,14 @@ export async function handleTokenConfig(app, html) {
         if (Object.keys(updatePayload).length > 0) {
             await actor.update(updatePayload);
             ui.notifications.info("Visage data saved.");
+            
+            // D) Force the HUD to refresh (ensuring the UI catches up)
+            const canvasToken = canvas.tokens.get(tokenDocument.id);
+            if (canvasToken) {
+                canvasToken.refresh();
+            }
+            // ----------------------------------------------------------------------------------
+            
         } else {
             ui.notifications.info("No changes to save.");
         }

--- a/visage-selector.js
+++ b/visage-selector.js
@@ -33,9 +33,18 @@ export class VisageSelector extends Application {
      * @override
      */
     async getData(options = {}) {
-        const actor = game.actors.get(this.actorId);
+        // Find the specific token instance on the canvas
+        const token = canvas.tokens.get(this.tokenId);
+        if (!token) {
+            ui.notifications.error(`VisageSelector: Could not find token with ID ${this.tokenId}`);
+            return { forms: [] };
+        }
+        
+        // Use the token's actor, which correctly references the embedded data for unlinked tokens.
+        const actor = token.actor; 
+        
         if (!actor) {
-            ui.notifications.error("VisageSelector: Could not find actor with ID " + this.actorId);
+            ui.notifications.error("VisageSelector: Could not find actor for token " + this.tokenId);
             return { forms: [] };
         }
 

--- a/visage.js
+++ b/visage.js
@@ -83,15 +83,16 @@ export class Visage {
      */
     static async setVisage(actorId, tokenId, formKey) {
         this.log(`Setting visage for token ${tokenId} (actor ${actorId}) to ${formKey}`);
-        const actor = game.actors.get(actorId);
-        if (!actor) {
-            this.log(`Actor not found: ${actorId}`, true);
-            return false;
-        }
         
         const token = canvas.tokens.get(tokenId);
         if (!token) {
             this.log(`Token not found: ${tokenId}`, true);
+            return false;
+        }
+
+        const actor = token.actor;
+        if (!actor) {
+            this.log(`Actor not found for token: ${tokenId}`, true);
             return false;
         }
 


### PR DESCRIPTION
Addresses issues where data could not be read or updated for tokens not linked to actors. Updates logic to reference the token's actor instance, ensuring correct behavior for unlinked tokens. Also refreshes the HUD after saving data to keep the UI in sync.