### PR TITLE
Fix scale reset bug when restoring default token

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Software and associated documentation files in this repository are covered by an
 
 | Version | Changes |
 | :--- | :--- |
+| **Version 0.3.2** | Fix bug when restoring scale to default |
 | **Version 0.3.1** | Fix label in configuration tab |
 | **Version 0.3.0** | Add a token image scaling feature, including option to flip the image |
 | **Version 0.2.4** | *  Add module setting to remove visage data from tokens<br>*  Add star icon to default token tile in selector HUD<br>*  Add usage instructions to the README.md |

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "visage",
   "title": "Visage",
   "description": "Allow token art and actor portraits to be easily switched to alternative images, including image scaling.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "compatibility": {
     "minimum": "13",
     "verified": "13"


### PR DESCRIPTION
Corrects the scale restoration logic so that resetting a token to its default form uses the correct scale factor. Previously, the scale was incorrectly set, causing tokens to not return to their intended size. Also updates documentation and version to 0.3.2.