### PR TITLE
Fix flip option for token images

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Software and associated documentation files in this repository are covered by an
 
 | Version | Changes |
 | :--- | :--- |
+| **Version 0.3.4** | Fix flip option for token images |
 | **Version 0.3.3** | *  Fix bug when restoring scale to default (again)<br>*  Fix how wildcard paths are resolved to prevent the mystery man appearing |
 | **Version 0.3.2** | Fix bug when restoring scale to default |
 | **Version 0.3.1** | Fix label in configuration tab |

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "visage",
   "title": "Visage",
   "description": "Allow token art and actor portraits to be easily switched to alternative images, including image scaling.",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "compatibility": {
     "minimum": "13",
     "verified": "13"

--- a/visage.js
+++ b/visage.js
@@ -193,8 +193,7 @@ export class Visage {
             "name": newName,
             "texture.src": finalTokenPath,
             "texture.scaleX": newScale,
-            // FIX: Apply the factor equally to both axes.
-            "texture.scaleY": newScale 
+            "texture.scaleY": Math.abs(newScale) 
         }, { visageUpdate: true });
 
             // Update the actor flags for this token


### PR DESCRIPTION
Corrects the handling of the flip option by ensuring 'texture.scaleY' uses the absolute value of the scale. Updates documentation and bumps version to 0.3.4.