### PR TITLE
Feature: Add Visage to Sidebar Context Menu & Fix AppV2 Actor Sheet Integration

### DIFF
--- a/styles/visage.css
+++ b/styles/visage.css
@@ -1124,7 +1124,7 @@
 
 
 /* ==========================================================================
-   6. Actor Sheet Header Icon
+   6. Actor Sheet Header Icon and Context Menu Icon
    ========================================================================== */
 
 /* Applies the switch_account.svg as a mask to the <i> tag in the header button. */
@@ -1135,5 +1135,13 @@
     -webkit-mask: url('../icons/switch_account.svg') no-repeat center / contain;
     mask: url('../icons/switch_account.svg') no-repeat center / contain;
     background-color: currentColor;
-    margin-inline-end: 0.25em;
+}
+
+.context-items .visage-icon-mask {
+    height: 1.25em;
+    width: 1.25em;
+    vertical-align: middle;
+    background-color: currentColor;
+    position: relative;
+    top: -1px;
 }


### PR DESCRIPTION
This PR expands Visage access to the Actor Sidebar and resolves compatibility with ApplicationV2 actor sheets.

Sidebar Context Menu: Added a "Visage" option to the right-click menu for Actors in the sidebar. This allows configuration of actors not currently on a scene.

AppV2 Compatibility: Fixed the display of the Visage icon/title for ApplicationV2 actor sheets (e.g., dnd5e). It should now appear in the context menu (the "hamburger" icon).